### PR TITLE
[feat] - Button 컴포넌트 기능 구현

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,0 +1,14 @@
+import { PropsWithChildren, ButtonHTMLAttributes } from 'react'
+
+interface ButtonProps
+  extends PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>> {}
+
+const Button = ({ children, type = 'submit', ...props }: ButtonProps) => {
+  return (
+    <button type={type} {...props} className="rounded-md bg-pink-200 px-4 py-2">
+      {children}
+    </button>
+  )
+}
+
+export default Button

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,1 @@
+export { default as Button } from './Button'


### PR DESCRIPTION
## 📑 구현 사항 

- [x] Button 컴포넌트 구현

<br/>

## 🚧 참고 사항

```typescript
interface ButtonProps extends PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>> {}

const Button = ({ children, type = 'submit', ...props }: ButtonProps) => {
  return (
    <button type={type} {...props} className="rounded-md bg-pink-200 px-4 py-2">
      {children}
    </button>
  )
}
```

- 컴포넌트의 확장성을 위해 위와 같이 button의 type을 `PropsWithChildren`과 `ButtonHTMLAttributes`를 통해 자식 노드 children과 HTML의 모든 버튼 속성을 상속받을 수 있도록 했습니다.

- `{...props}`를 통해 추가되는 props를 적용시켜주고 있습니다.

- 마크업은 디자인 나온 후에 진행하면 될 것 같습니다~

</br>

close #4
